### PR TITLE
Apply polyfill to Ember.Engine in addition to Ember.Application

### DIFF
--- a/lib/helpers/expression-for-attribute-value.js
+++ b/lib/helpers/expression-for-attribute-value.js
@@ -15,6 +15,9 @@ module.exports = function expressionForAttributeValue(b, value) {
       return b.sexpr(value.path, value.params, value.hash, value.loc);
     }
   } else if (value.type === 'ConcatStatement') {
-    return b.sexpr('concat', value.parts.map(p => expressionForAttributeValue(b, p)));
+    return b.sexpr(
+      'concat',
+      value.parts.map(p => expressionForAttributeValue(b, p))
+    );
   }
 };

--- a/tests/integration/components/angle-bracket-invocation-test.js
+++ b/tests/integration/components/angle-bracket-invocation-test.js
@@ -15,7 +15,10 @@ module('Integration | Component | angle-bracket-invocation', function(hooks) {
 
   module('static component support', function() {
     test('does not affect helper usage', async function(assert) {
-      this.owner.register('helper:my-helper', buildHelper(() => 'my-helper'));
+      this.owner.register(
+        'helper:my-helper',
+        buildHelper(() => 'my-helper')
+      );
 
       await render(hbs`{{my-helper}}`);
 

--- a/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
+++ b/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
@@ -413,9 +413,8 @@ import { lte, gte } from 'ember-compatibility-helpers';
 
       return registry;
     };
-    for (const PolyfillTarget of [Application, Engine]) {
-      PolyfillTarget.reopenClass({ buildRegistry });
-    }
+    Application.reopenClass({ buildRegistry });
+    Engine.reopenClass({ buildRegistry });
   } else {
     // Based heavily on https://github.com/mmun/ember-component-attributes
     Component.reopen({

--- a/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
+++ b/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
@@ -249,9 +249,8 @@ import { lte, gte } from 'ember-compatibility-helpers';
 
       return registry;
     };
-    for (const PolyfillTarget of [Application, Engine]) {
-      PolyfillTarget.reopenClass({ buildRegistry });
-    }
+    Application.reopenClass({ buildRegistry });
+    Engine.reopenClass({ buildRegistry });
   } else if (gte('2.12.0-beta.1')) {
     const buildRegistry = function buildRegistry() {
       let registry = this._super(...arguments);


### PR DESCRIPTION
This is an updated version of the changes in #48, to fix #47. Like that PR, it applies the polyfill to both Ember.Application and Ember.Engine; since Ember.Application extends from Ember.Engine this might be unnecessary and the polyfill need only be applied to Ember.Engine, but this way is unlikely to break anything. (Happy to update the PR if it's preferable to just apply to Ember.Engine.)

There aren't a lot of non-whitespace changes here; you might want to use Github's "Hide whitespace changes" feature to see the substantive changes.