### PR TITLE
Fix monkey patching in Ember 2.x polyfill code paths

### DIFF
--- a/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
+++ b/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
@@ -2,10 +2,6 @@
 /* eslint-disable ember/new-module-imports */
 import { lte, gte } from 'ember-compatibility-helpers';
 
-console.log(`Ember ${Ember.VERSION}`);
-window.didCreateElementDepth = 0;
-window.didCreateElementMaxDepth = 0;
-
 (function() {
   const P = Ember.__loader.require('container').privatize;
   const { Application, Component, Engine, computed, getOwner } = Ember;
@@ -229,11 +225,6 @@ window.didCreateElementMaxDepth = 0;
 
             let ORIGINAL_DID_CREATE_ELEMENT = manager.didCreateElement;
             manager.didCreateElement = function(bucket, element, operations) {
-              window.didCreateElementDepth++;
-              if (window.didCreateElementMaxDepth < window.didCreateElementDepth) {
-                window.didCreateElementMaxDepth = window.didCreateElementDepth;
-                console.log('new didCreateElement max depth:', window.didCreateElementMaxDepth);
-              }
               ORIGINAL_DID_CREATE_ELEMENT.apply(this, arguments);
               let { args } = bucket;
               if (args.has('__ANGLE_ATTRS__')) {
@@ -247,7 +238,6 @@ window.didCreateElementMaxDepth = 0;
                   }
                 }
               }
-              window.didCreateElementDepth--;
             };
           }
 
@@ -383,11 +373,6 @@ window.didCreateElementMaxDepth = 0;
 
               let ORIGINAL_DID_CREATE_ELEMENT = manager.didCreateElement;
               manager.didCreateElement = function(bucket, element, operations) {
-                window.didCreateElementDepth++;
-                if (window.didCreateElementMaxDepth < window.didCreateElementDepth) {
-                  window.didCreateElementMaxDepth = window.didCreateElementDepth;
-                  console.log('new didCreateElement max depth:', window.didCreateElementMaxDepth);
-                }
                 ORIGINAL_DID_CREATE_ELEMENT.apply(this, arguments);
                 let { args } = bucket;
 
@@ -415,7 +400,6 @@ window.didCreateElementMaxDepth = 0;
                     }
                   }
                 }
-                window.didCreateElementDepth--;
               };
             }
 

--- a/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
+++ b/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
@@ -2,6 +2,10 @@
 /* eslint-disable ember/new-module-imports */
 import { lte, gte } from 'ember-compatibility-helpers';
 
+console.log(`Ember ${Ember.VERSION}`);
+window.didCreateElementDepth = 0;
+window.didCreateElementMaxDepth = 0;
+
 (function() {
   const P = Ember.__loader.require('container').privatize;
   const { Application, Component, Engine, computed, getOwner } = Ember;
@@ -225,6 +229,11 @@ import { lte, gte } from 'ember-compatibility-helpers';
 
             let ORIGINAL_DID_CREATE_ELEMENT = manager.didCreateElement;
             manager.didCreateElement = function(bucket, element, operations) {
+              window.didCreateElementDepth++;
+              if (window.didCreateElementMaxDepth < window.didCreateElementDepth) {
+                window.didCreateElementMaxDepth = window.didCreateElementDepth;
+                console.log('new didCreateElement max depth:', window.didCreateElementMaxDepth);
+              }
               ORIGINAL_DID_CREATE_ELEMENT.apply(this, arguments);
               let { args } = bucket;
               if (args.has('__ANGLE_ATTRS__')) {
@@ -238,6 +247,7 @@ import { lte, gte } from 'ember-compatibility-helpers';
                   }
                 }
               }
+              window.didCreateElementDepth--;
             };
           }
 
@@ -373,6 +383,11 @@ import { lte, gte } from 'ember-compatibility-helpers';
 
               let ORIGINAL_DID_CREATE_ELEMENT = manager.didCreateElement;
               manager.didCreateElement = function(bucket, element, operations) {
+                window.didCreateElementDepth++;
+                if (window.didCreateElementMaxDepth < window.didCreateElementDepth) {
+                  window.didCreateElementMaxDepth = window.didCreateElementDepth;
+                  console.log('new didCreateElement max depth:', window.didCreateElementMaxDepth);
+                }
                 ORIGINAL_DID_CREATE_ELEMENT.apply(this, arguments);
                 let { args } = bucket;
 
@@ -400,6 +415,7 @@ import { lte, gte } from 'ember-compatibility-helpers';
                     }
                   }
                 }
+                window.didCreateElementDepth--;
               };
             }
 

--- a/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
+++ b/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
@@ -275,8 +275,8 @@ import { lte, gte } from 'ember-compatibility-helpers';
         })
       );
       let Environment = registry.resolve('service:-glimmer-environment');
-      let ORIGINAL_ENVIRONMENT_CREATE = Environment.create;
       if (!Environment.create.__IS_ANGLE_BRACKET_PATCHED__) {
+        let ORIGINAL_ENVIRONMENT_CREATE = Environment.create;
         Environment.create = function() {
           let environment = ORIGINAL_ENVIRONMENT_CREATE.apply(this, arguments);
           let installedCustomDidCreateElement = false;
@@ -371,36 +371,39 @@ import { lte, gte } from 'ember-compatibility-helpers';
 
               let { manager } = definition;
 
-              let ORIGINAL_DID_CREATE_ELEMENT = manager.didCreateElement;
-              manager.didCreateElement = function(bucket, element, operations) {
-                ORIGINAL_DID_CREATE_ELEMENT.apply(this, arguments);
-                let { args } = bucket;
+              if (!manager.didCreateElement.__IS_ANGLE_BRACKET_PATCHED__) {
+                let ORIGINAL_DID_CREATE_ELEMENT = manager.didCreateElement;
+                manager.didCreateElement = function(bucket, element, operations) {
+                  ORIGINAL_DID_CREATE_ELEMENT.apply(this, arguments);
+                  let { args } = bucket;
 
-                if (lte('2.15.0-beta.1')) {
-                  args = args.namedArgs;
-                }
+                  if (lte('2.15.0-beta.1')) {
+                    args = args.namedArgs;
+                  }
 
-                // on < 2.15 `namedArgs` is only present when there were arguments
-                if (args && args.has('__ANGLE_ATTRS__')) {
-                  let attributeReferences = args.get('__ANGLE_ATTRS__');
-                  let snapshot = attributeReferences.value();
-                  if (snapshot) {
-                    let names = Object.keys(snapshot);
-                    for (let i = 0; i < names.length; i++) {
-                      let attributeName = names[i];
-                      let attributeReference = attributeReferences.get(attributeName);
+                  // on < 2.15 `namedArgs` is only present when there were arguments
+                  if (args && args.has('__ANGLE_ATTRS__')) {
+                    let attributeReferences = args.get('__ANGLE_ATTRS__');
+                    let snapshot = attributeReferences.value();
+                    if (snapshot) {
+                      let names = Object.keys(snapshot);
+                      for (let i = 0; i < names.length; i++) {
+                        let attributeName = names[i];
+                        let attributeReference = attributeReferences.get(attributeName);
 
-                      operations.addDynamicAttribute(
-                        element,
-                        attributeName,
-                        attributeReference,
-                        false,
-                        null
-                      );
+                        operations.addDynamicAttribute(
+                          element,
+                          attributeName,
+                          attributeReference,
+                          false,
+                          null
+                        );
+                      }
                     }
                   }
-                }
-              };
+                };
+                manager.didCreateElement.__IS_ANGLE_BRACKET_PATCHED__ = true;
+              }
             }
 
             return definition;


### PR DESCRIPTION
This PR fixes the bug identified in https://github.com/ember-polyfills/ember-angle-bracket-invocation-polyfill/issues/53. The fix in https://github.com/ember-polyfills/ember-angle-bracket-invocation-polyfill/pull/55 was only a partial fix: we also need to fix the monkey patching of `manager.didCreateElement`.

I noticed this because our CI (which has 1000s of tests) was crashing with a stack overflow.

The first commit in this PR contains a set of log statements that I added to demonstrate the problem. They're reverted in the second commit (and can be squashed out before merging). The third commit is the fix.

It's tricky to write a test for this that doesn't involve a very long test suite or even more monkey patching of an already complicated situation, so I opted to add some logging and to share some screenshots instead. The log statements are used to keep track of how deeply recursive the `manager.didCreateElement` calls get. You can see from the screenshots below that in Ember 2.12 and Ember 2.18 they grow linearly, but they should always be exactly one. The problem does not occur in Ember 3.3. After the fix is applied there are no recursive calls in any of the 3 versions I tested.

**Before the fix (Ember 2.12):**

<img width="2652" alt="Before - Ember 2 12 2" src="https://user-images.githubusercontent.com/1151810/115780006-a7238480-a386-11eb-99a9-638efbb0df66.png">

**Before the fix (Ember 2.18):**

<img width="2652" alt="Before - Ember 2 18 2" src="https://user-images.githubusercontent.com/1151810/115780179-d6d28c80-a386-11eb-8dd4-b7c697a5071a.png">

**Before the fix (Ember 3.3):**

<img width="2652" alt="Before - Ember 3 3 2" src="https://user-images.githubusercontent.com/1151810/115780198-dafeaa00-a386-11eb-9bde-d54172559e51.png">

**After the fix (Ember 2.12):**

<img width="2672" alt="After - Ember 2 12 2" src="https://user-images.githubusercontent.com/1151810/115780203-dd610400-a386-11eb-9664-45242c3f74aa.png">

**After the fix (Ember 2.18):**

<img width="2672" alt="After - Ember 2 18 2" src="https://user-images.githubusercontent.com/1151810/115780208-de923100-a386-11eb-9f75-5767a28e3e1c.png">
